### PR TITLE
fix compilation errors of the code example

### DIFF
--- a/src/generics/assoc_items/types.md
+++ b/src/generics/assoc_items/types.md
@@ -41,7 +41,7 @@ trait Contains {
     type A;
     type B;
 
-    fn contains(&self, &Self::A, &Self::B) -> bool;
+    fn contains(&self, number_1: &Self::A, number_2: &Self::B) -> bool;
     fn first(&self) -> i32;
     fn last(&self) -> i32;
 }


### PR DESCRIPTION
Method `contains` in the Contains trait had not input variable names. That is way the code was not compiled. After fix this the code was compiled and provide all described functionality.