### PR TITLE
fix warning

### DIFF
--- a/src/scope/raii.md
+++ b/src/scope/raii.md
@@ -85,7 +85,7 @@ impl Drop for ToDrop {
 }
 
 fn main() {
-    let x = ToDrop;
+    let _x = ToDrop;
     println!("Made a ToDrop!");
 }
 ```


### PR DESCRIPTION
Fix warning:
12 |     let x = ToDrop;
   |         ^ help: consider using `_x` instead