### PR TITLE
Fix syntax of the example

### DIFF
--- a/src/scope/borrow/freeze.md
+++ b/src/scope/borrow/freeze.md
@@ -4,21 +4,22 @@
 не могут быть изменены до тех пор, пока все ссылки не выйдут за область видимости:
 
 ```rust,editable,ignore,mdbook-runnable
+#[allow(unused_assignments)]
 fn main() {
-    let mut _mutable_integer = 7i32;
+    let mut mutable_integer = 7i32;
 
     {
         // Заимствовать `_mutable_integer`
-        let _large_integer = &_mutable_integer;
+        let _large_integer = &mutable_integer;
 
         // Ошибка! `_mutable_integer` заморожен в этой области видимости
-        _mutable_integer = 50;
+        mutable_integer = 50;
         // ИСПРАВЬТЕ ^ Закомментируйте эту строку
 
         // `_large_integer` покидает область видимости
     }
 
     // Ок! `_mutable_integer` не заморожен в этой области видимости
-    _mutable_integer = 3;
+    mutable_integer = 3;
 }
 ```


### PR DESCRIPTION
While using variable with `_` prefix compiler do not do all checking. That is why we do not get expected behavior of this example. To fix it remove `_` prefix. I have done it and get expected behavior of the compiler.  
Also I add `#[allow(unused_assignments)]` to remove warning message.