### PR TITLE
Fix warning `unused_imports`

### DIFF
--- a/src/error/multiple_error_types/wrap_error.md
+++ b/src/error/multiple_error_types/wrap_error.md
@@ -4,7 +4,6 @@ An alternative to boxing errors is to wrap them in your own error type.
 
 ```rust,editable
 use std::error;
-use std::num::ParseIntError;
 use std::fmt;
 
 type Result<T> = std::result::Result<T, DoubleError>;


### PR DESCRIPTION
note: #[warn(unused_imports)] on by default
Remove unused import